### PR TITLE
Bump to version 0.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>mithril</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.3-SNAPSHOT</version>
     <name>mithril.js</name>
     <description>WebJar for Mithril</description>
     <url>http://webjars.org</url>
@@ -45,7 +45,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.2.0</upstream.version>
+        <upstream.version>0.2.3</upstream.version>
         <upstream.url>https://github.com/lhorie/mithril.js/archive</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>


### PR DESCRIPTION
Mithril 0.2.3 was released on 2nd May 2016 and contains a few bug
fixes[1](https://github.com/lhorie/mithril.js/releases/tag/v0.2.3).
